### PR TITLE
Prevent leaked handlers.

### DIFF
--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -113,7 +113,7 @@ Listener.prototype.setVerbose = function(verbose) {
 Listener.prototype.connect = function(callback) {
     this.serviceSocket.connect(this.port, this.hostname);
 
-    this.serviceSocket.on('connect', function (socket) {
+    this.serviceSocket.once('connect', function (socket) {
         if (callback !== undefined) callback.call();
     });
 }
@@ -123,7 +123,7 @@ Listener.prototype.disconnect = function(callback) {
     this.unwatch();
 
     this.serviceSocket.end();
-    this.serviceSocket.on('close', function(err) {
+    this.serviceSocket.once('close', function(err) {
         if (callback !== undefined) callback.call();
     });
 }


### PR DESCRIPTION
This is an issue when repeatedly connecting and disconnecting on the same Listener.

I've debugged the source and found that this is because the `connect` and `disconnect` methods are not cleaning up old listeners.

Say we are sampling infrequently with this code:

``` javascript
var listener = new gpsd.Listener();
listener.on("TPV", writeToDisk);

setInterval(function() {
    listener.connect();
    setTimeout(function() { listener.disconnect(); }, 1 * 1000);
}, 60*1000)
```

I get a warning after 10 intervals that there are more than 10 listeners on the serviceSocket. 

This is due to the `this.serviceSocket.on('connect')` and `this.serviceSocket.on('close')` lines at [L116](../blob/master/lib/gpsd.js#L116) and [L126](../blob/master/lib/gpsd.js#L126). 
