### PR TITLE
connect/disconnect conserve event handlers

### DIFF
--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -113,9 +113,11 @@ exports.Listener = Listener;
 Listener.prototype.connect = function(callback) {
     this.serviceSocket.connect(this.port, this.hostname);
 
-    this.serviceSocket.once('connect', function (socket) {
-        if (callback !== undefined) callback.call();
-    });
+    if(callback !== undefined) {
+      this.serviceSocket.once('connect', function(socket) {
+          callback(socket);
+      });
+    }
 };
 
 /* disconnects from GPSd */
@@ -123,10 +125,12 @@ Listener.prototype.disconnect = function(callback) {
     this.unwatch();
 
     this.serviceSocket.end();
-    this.serviceSocket.once('close', function(err) {
-        if (callback !== undefined) callback.call();
-    });
-};
+    
+    if(callback !== undefined) {
+      this.serviceSocket.once('close', function(err) {
+          callback(err);
+      });
+    }};
 
 /* Checks the state of the connection */
 Listener.prototype.isConnected = function() {


### PR DESCRIPTION
I have a scenario where gpsd runs on a different device than the node application, and therefore gpsd may not be available at all times.  This necessitates calling connect in a delayed loop after a disconnect is detected.

I see there has been a previous pull request made to attempt to address the issue of leaking handlers within connect/disconnect, but changing from .on to .once still adds a handler every time the function is called, it just makes sure that the accumulation of handlers get called only once when a connect is eventually achieved.

The method that worked for me is, since the only function of the handler is to call the given callback, if there isn't a callback, don't register the handler.  In my initial and subsequent calls to connect, I don't use a callback, so no additional handlers are registered.  Once a connection is successful, the connection event handler does any initialization or notification that is needed, eliminating the need for a callback.

Thanks for making and maintaining this library, it's made my GPS project much easier!