### PR TITLE
Fix starting deamon without GPS device attached

### DIFF
--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -225,7 +225,7 @@ Daemon.prototype.start = function(callback) {
             p.apply(this, [ callback ]);
         } else {
             self.logger.info("Device not found. watching device.");
-            fs.watchFile(this.device, function (curr, prev) {
+            fs.watchFile(self.device, function (curr, prev) {
                 self.logger.info("device status changed.");
                 p.apply(this, [ callback ]);
             });


### PR DESCRIPTION
Without a GPS device attached gpsd will fail with the following exception:
path.js:439
      throw new TypeError('Arguments to path.resolve must be strings');
            ^
TypeError: Arguments to path.resolve must be strings
    at Object.posix.resolve (path.js:439:13)
    at Object.fs.watchFile (fs.js:1256:25)
    at /Users/sanne/Development/ping/node_modules/node-gpsd/lib/gpsd.js:228:16
    at FSReqWrap.cb [as oncomplete] (fs.js:226:19)