### PR TITLE
Set parse just like other defaults.

### DIFF
--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -33,16 +33,13 @@ function Listener(options) {
         warn: console.warn,
         error: console.error
     };
+    this.parse = true;
 
     if (options !== undefined) {
         if (options.port !== undefined) this.port = options.port;
         if (options.hostname !== undefined) this.hostname = options.hostname;
         if (options.logger !== undefined) this.logger = options.logger;
-        if (options.parse !== undefined) {
-            this.parse = options.parse;
-        } else {
-            this.parse = true;
-        }
+        if (options.parse !== undefined) this.parse = options.parse;
     }
 
     events.EventEmitter.call(this);


### PR DESCRIPTION
This appears to fix my issue with events not being sent.  It should do exactly the same thing, but apparently it does not...  It does normalize how defaults are set though, so that's good on its own.