### PR TITLE
Bubble error event up from GPSD spawn so that the library doesn't crash on spawn errors

### DIFF
--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -208,6 +208,10 @@ Daemon.prototype.start = function(callback) {
                     self.emit('died');
                 });
 
+                self.gpsd.on('error', function (err) {
+                    self.emit('error', err);
+                });
+
                 // give the daemon a change to startup before makeing the callback.
                 setTimeout(function() {
                     if (callback !== undefined) callback.call();


### PR DESCRIPTION
Bubble error event up from GPSD spawn so that the library doesn't crash on spawn errors