### PR TITLE
Add a read-only option to the Daemon class

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,6 +30,7 @@ var daemon = new gpsd.Daemon({
     device: '/dev/ttyUSB0',
     port: 2947,
     pid: '/tmp/gpsd.pid',
+    readOnly: false,
     logger: {
         info: function() {},
         warn: console.warn,

--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -163,6 +163,7 @@ function Daemon(options) {
     this.device = '/dev/ttyUSB0';
     this.port = DEFAULT_PORT;
     this.pid = '/tmp/gpsd.pid';
+    this.readOnly = false;
     this.logger = {
         info: function() {},
         warn: console.warn,
@@ -176,6 +177,7 @@ function Daemon(options) {
         if (options.device !== undefined) this.device = options.device;
         if (options.port !== undefined) this.port = options.port;
         if (options.pid !== undefined) this.pid = options.pid;
+        if (options.readOnly !== undefined) this.readOnly = options.readOnly;
         if (options.logger !== undefined) this.logger = options.logger;
     }
 
@@ -187,6 +189,7 @@ function Daemon(options) {
     this.arguments.push('-S');
     this.arguments.push(this.port);
     this.arguments.push(this.device);
+    if (this.readOnly) this.arguments.push('-b');
 }
 
 util.inherits(Daemon, events.EventEmitter);


### PR DESCRIPTION
The `readOnly` option accepts a `Boolean` and passes the "Broken-device-safety-mode" (`-b`) option to `gpsd`.

From the `gpsd` [docs](http://www.catb.org/gpsd/gpsd.html):
> Broken-device-safety mode, otherwise known as read-only mode. A few bluetooth and USB receivers lock up or become totally inaccessible when probed or reconfigured; see the hardware compatibility list on the GPSD project website for details. This switch prevents gpsd from writing to a receiver. This means that gpsd cannot configure the receiver for optimal performance, but it also means that gpsd cannot break the receiver. A better solution would be for Bluetooth to not be so fragile. A platform independent method to identify serial-over-Bluetooth devices would also be nice.