### PR TITLE
Allow for a Listener object to re-connect upon disconnection.

### DIFF
--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -24,32 +24,17 @@ var path = require('path');
 
 var DEFAULT_PORT = 2947;
 
-/* Construct the listener */
-function Listener(options) {
-    this.port = DEFAULT_PORT;
-    this.hostname = 'localhost';
-    this.logger = {
-        info: function() {},
-        warn: console.warn,
-        error: console.error
-    };
-    this.parse = true;
+function createServiceSocket(self) {
+    let sock = new net.Socket();
+    sock.setEncoding('ascii');
 
-    if (options !== undefined) {
-        if (options.port !== undefined) this.port = options.port;
-        if (options.hostname !== undefined) this.hostname = options.hostname;
-        if (options.logger !== undefined) this.logger = options.logger;
-        if (options.parse !== undefined) this.parse = options.parse;
-    }
+    sock.on('connect', function (socket) {
+        self.logger.info('Socket connected.');
+        self.connected = true;
+        self.emit('connected');
+    });
 
-    events.EventEmitter.call(this);
-
-    var self = this;
-    this.connected = false;
-    this.serviceSocket = new net.Socket();
-    this.serviceSocket.setEncoding('ascii');
-
-    this.serviceSocket.on("data", function (payload) {
+    sock.on("data", function (payload) {
         payload = payload.replace(/\}\{/g, '}\n{');
         var info = payload.split('\n'), data;
 
@@ -76,19 +61,13 @@ function Listener(options) {
         }
     });
 
-    this.serviceSocket.on("close", function (err) {
+    sock.on("close", function (err) {
         self.logger.info('Socket disconnected.');
         self.emit('disconnected', err);
         self.connected = false;
     });
 
-    this.serviceSocket.on('connect', function (socket) {
-        self.logger.info('Socket connected.');
-        self.connected = true;
-        self.emit('connected');
-    });
-
-    this.serviceSocket.on('error', function (error) {
+    sock.on('error', function (error) {
         if (error.code === 'ECONNREFUSED') {
             self.logger.error('socket connection refused');
             self.emit('error.connection');
@@ -98,6 +77,32 @@ function Listener(options) {
         }
     });
 
+    return sock;
+}
+
+/* Construct the listener */
+function Listener(options) {
+    this.port = DEFAULT_PORT;
+    this.hostname = 'localhost';
+    this.logger = {
+        info: function() {},
+        warn: console.warn,
+        error: console.error
+    };
+    this.parse = true;
+
+    if (options !== undefined) {
+        if (options.port !== undefined) this.port = options.port;
+        if (options.hostname !== undefined) this.hostname = options.hostname;
+        if (options.logger !== undefined) this.logger = options.logger;
+        if (options.parse !== undefined) this.parse = options.parse;
+    }
+
+    events.EventEmitter.call(this);
+
+    var self = this;
+    this.connected = false;
+
     return (this);
 }
 
@@ -106,6 +111,13 @@ exports.Listener = Listener;
 
 /* connects to GPSd */
 Listener.prototype.connect = function(callback) {
+    // create or destroy the socket
+    if (this.serviceSocket) {
+        this.serviceSocket.destroy();
+        this.serviceSocket.removeAllListeners();
+        this.serviceSocket = null;
+    }
+    this.serviceSocket = createServiceSocket(this);
     this.serviceSocket.connect(this.port, this.hostname);
 
     if(callback !== undefined) {
@@ -239,7 +251,7 @@ Daemon.prototype.start = function(callback) {
 Daemon.prototype.stop = function(callback) {
     this.gpsd.on('exit', function (code) {
         if (callback !== undefined) {
-            callback.call(); 
+            callback.call();
         }
     });
 


### PR DESCRIPTION
Thanks for your work on this library as I was looking to monitor a gpsd in a nodejs-based service I have written and this fits that bill great.

The P/R allows the Listener.connect() method to be called multiple times without getting confused. The idea is that if an application doesn't get a connection or loses a connection to gpsd, it should be able to retry. With this module, the connect() method appears to be the way to do that but calling it multiple times isn't really supported since the underlying service socket isn't managed in a way to make that possible.

I've tested the changes on a Linux host (Debian) that uses systemd and services for gpsd.socket and gpsd.

I've attached a simple test case ([here](https://github.com/eelcocramer/node-gpsd/files/4899110/test-gpsd.txt)).

Run the test without the changes and with the gpsd.socket service stopped and the multiple calls to connect() will start piling up the errors. With changes, stopping and starting the gpsd.socket will work as I would have expected.