### PR TITLE
Fix #19: Wait for complete message before parsing

### DIFF
--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -76,7 +76,8 @@ function createServiceSocket(self) {
                                 error : error
                             });
     
-                            continue;                        }
+                            continue;
+                        }
                     }
                 }
             }

--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -42,7 +42,7 @@ function createServiceSocket(self) {
                 // Short-circuit: there's no prior bytes.
                 parseOneOrMoreCompleteMessages(payload);
             }
-            else {
+            } else {
                 // There are prior bytes.
                 self.partialMessages.push(payload);
                 parseOneOrMoreCompleteMessages(Buffer.concat(self.partialMessages));

--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -48,7 +48,7 @@ function createServiceSocket(self) {
                 self.partialMessages = [];
             }
         }
-        else {
+        } else {
             // Not a complete message.  Push the buffer until we know more.
             self.partialMessages.push(payload);
         }

--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -36,7 +36,7 @@ function createServiceSocket(self) {
     });
 
     sock.on("data", function (payload) {
-        if (payload[payload.length - 1] == 10) {
+        if (payload[payload.length - 1] === '\n') {
             // End of a possible sequence of messages.  Squish all the messages together if necessary, then parse.
             if (self.partialMessages.length === 0) {
                 // Short-circuit: there's no prior bytes.

--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -31,30 +31,52 @@ function createServiceSocket(self) {
     sock.on('connect', function (socket) {
         self.logger.info('Socket connected.');
         self.connected = true;
+        self.partialMessages = [];
         self.emit('connected');
     });
 
     sock.on("data", function (payload) {
-        payload = payload.replace(/\}\{/g, '}\n{');
-        var info = payload.split('\n'), data;
+        if (payload[payload.length - 1] == 10) {
+            // End of a possible sequence of messages.  Squish all the messages together if necessary, then parse.
+            if (self.partialMessages.length === 0) {
+                // Short-circuit: there's no prior bytes.
+                parseOneOrMoreCompleteMessages(payload);
+            }
+            else {
+                // There are prior bytes.
+                self.partialMessages.push(payload);
+                parseOneOrMoreCompleteMessages(Buffer.concat(self.partialMessages));
+                self.partialMessages = [];
+            }
+        }
+        else {
+            // Not a complete message.  Push the buffer until we know more.
+            self.partialMessages.push(payload);
+        }
 
-        for (var index = 0; index < info.length; index++) {
-            if (info[index]) {
-                if (!self.parse) {
-                    self.emit('raw', info[index]);
-                } else {
-                    try {
-                        data = JSON.parse(info[index]);
-                        self.emit(data.class, data);
-                    } catch (error) {
-                        self.logger.error("Bad message format", info[index], error);
-                        self.emit('error', {
-                            message : "Bad message format",
-                            cause : info[index],
-                            error : error
-                        });
+        function parseOneOrMoreCompleteMessages(completeMessages) {
+            // Payload is a Buffer, and we ideally want to do some string-splitting on it. Convert to string, therefore.
+            var completeMessagesString = completeMessages.toString('ascii');
+            var stringPayload = completeMessagesString.replace(/\}\{/g, '}\n{');
+            var info = stringPayload.split('\n');
 
-                        continue;
+            for (var index = 0; index < info.length; index++) {
+                if (info[index]) {
+                    if (!self.parse) {
+                        self.emit('raw', info[index]);
+                    } else {
+                        try {
+                            var data = JSON.parse(info[index]);
+                            self.emit(data.class, data);
+                        } catch (error) {
+                            self.logger.error("Bad message format", info[index], error);
+                            self.emit('error', {
+                                message : "Bad message format",
+                                cause : info[index],
+                                error : error
+                            });
+    
+                            continue;                        }
                     }
                 }
             }

--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -47,7 +47,6 @@ function createServiceSocket(self) {
                 parseOneOrMoreCompleteMessages(Buffer.concat(self.partialMessages));
                 self.partialMessages = [];
             }
-        }
         } else {
             // Not a complete message.  Push the buffer until we know more.
             self.partialMessages.push(payload);

--- a/lib/gpsd.js
+++ b/lib/gpsd.js
@@ -41,7 +41,6 @@ function createServiceSocket(self) {
             if (self.partialMessages.length === 0) {
                 // Short-circuit: there's no prior bytes.
                 parseOneOrMoreCompleteMessages(payload);
-            }
             } else {
                 // There are prior bytes.
                 self.partialMessages.push(payload);


### PR DESCRIPTION
Handles a relatively rare condition where a remote gpsd is being accessed and JSON messages are split because they're larger than the network can send in one frame.